### PR TITLE
One device per user

### DIFF
--- a/lib/acolyte_trials/devices/device.ex
+++ b/lib/acolyte_trials/devices/device.ex
@@ -14,6 +14,6 @@ defmodule AcolyteTrials.Devices.Device do
     device
     |> cast(attrs, [:config_hash, :user_id])
     |> validate_required([:config_hash])
-    |> unique_constraint(:user_id)
+    |> unique_constraint(:user_id, message: "User already has a device assigned")
   end
 end

--- a/lib/acolyte_trials/devices/device.ex
+++ b/lib/acolyte_trials/devices/device.ex
@@ -14,5 +14,6 @@ defmodule AcolyteTrials.Devices.Device do
     device
     |> cast(attrs, [:config_hash, :user_id])
     |> validate_required([:config_hash])
+    |> unique_constraint(:user_id)
   end
 end

--- a/lib/acolyte_trials_web/templates/device/form.html.eex
+++ b/lib/acolyte_trials_web/templates/device/form.html.eex
@@ -12,6 +12,7 @@
   <%= label f, :user_id, "User" %>
   <%= select f, :user_id, user_select_options(@users),
       prompt: "Choose a user" %>
+  <%= error_tag f, :user_id %>
 
   <div>
     <%= submit "Save" %>

--- a/priv/repo/migrations/20191115161140_create_devices.exs
+++ b/priv/repo/migrations/20191115161140_create_devices.exs
@@ -10,6 +10,6 @@ defmodule AcolyteTrials.Repo.Migrations.CreateDevices do
     end
 
     create(unique_index(:devices, [:config_hash]))
-    create(index(:devices, [:user_id]))
+    create(unique_index(:devices, [:user_id]))
   end
 end


### PR DESCRIPTION
When assigning a device to a user, if the user already has a device assigned, an error will be shown and update not made to the database.
* Unique index added to `devices` table
* unique_constraint check added to `devices` changeset with a custom message "User already has a device assigned"
* Added error_tag to user select field on Device creation and edit screens

closes #9 
