### PR TITLE
Add websocket auth for devices

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       # - ./container_mix_artifacts:/opt/mix_artifacts
   
   db:
-    image: "postgres:9.6.11"
+    image: "postgres"
     ports:
       - 6543:5432
 

--- a/lib/acolyte_trials/accounts/user.ex
+++ b/lib/acolyte_trials/accounts/user.ex
@@ -3,8 +3,6 @@ defmodule AcolyteTrials.Accounts.User do
   import Ecto.Changeset
   import Ecto.Query
 
-  alias AcolyteTrials.Accounts.User
-
   schema "users" do
     field :name, :string
     field :github_username, :string

--- a/lib/acolyte_trials/devices.ex
+++ b/lib/acolyte_trials/devices.ex
@@ -57,7 +57,9 @@ defmodule AcolyteTrials.Devices do
     nil
   """
   def get_device_by(params) do
-    Repo.get_by(Device, params)
+    Device
+    |> Repo.get_by(params)
+    |> Repo.preload(:user)
   end
 
   @doc """

--- a/lib/acolyte_trials/devices.ex
+++ b/lib/acolyte_trials/devices.ex
@@ -7,7 +7,6 @@ defmodule AcolyteTrials.Devices do
   alias AcolyteTrials.Repo
 
   alias AcolyteTrials.Devices.Device
-  alias AcolyteTrials.Accounts
 
   @doc """
   Returns the list of devices.
@@ -42,6 +41,23 @@ defmodule AcolyteTrials.Devices do
     Device
     |> Repo.get!(id)
     |> Repo.preload(:user)
+  end
+
+  @doc """
+  Gets a single device by attribute
+
+  Returns nil if no device is found
+
+  ## Examples
+
+    iex> get_device_by(config_hash: "123")
+    %Device{}
+
+    iex> get_device_by(config_hash: "nonexistent")
+    nil
+  """
+  def get_device_by(params) do
+    Repo.get_by(Device, params)
   end
 
   @doc """

--- a/lib/acolyte_trials_web/channels/device_channel.ex
+++ b/lib/acolyte_trials_web/channels/device_channel.ex
@@ -1,0 +1,7 @@
+defmodule AcolyteTrialsWeb.DeviceChannel do
+  use AcolyteTrialsWeb, :channel
+
+  def join("devices:" <> _device_id, _payload, socket) do
+    {:ok, socket}
+  end
+end

--- a/lib/acolyte_trials_web/channels/user_socket.ex
+++ b/lib/acolyte_trials_web/channels/user_socket.ex
@@ -1,8 +1,11 @@
 defmodule AcolyteTrialsWeb.UserSocket do
   use Phoenix.Socket
 
+  alias AcolyteTrials.Devices
+
   ## Channels
   # channel "room:*", AcolyteTrialsWeb.RoomChannel
+  channel "devices:*", AcolyteTrialsWeb.DeviceChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
@@ -15,8 +18,18 @@ defmodule AcolyteTrialsWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(_params, socket, _connect_info) do
-    {:ok, socket}
+  def connect(%{"token" => device_id}, socket, _connect_info) do
+    case Devices.get_device_by(config_hash: device_id) do
+      %Devices.Device{} ->
+        {:ok, assign(socket, :device_id, device_id)}
+
+      _ ->
+        :error
+    end
+  end
+
+  def connect(_params, _socket, _connect_info) do
+    :error
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:
@@ -29,5 +42,6 @@ defmodule AcolyteTrialsWeb.UserSocket do
   #     AcolyteTrialsWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
   #
   # Returning `nil` makes this socket anonymous.
+  def id(%{assigns: %{device_id: device_id}}), do: "device_socket:#{device_id}"
   def id(_socket), do: nil
 end

--- a/test/acolyte_trials/accounts_test.exs
+++ b/test/acolyte_trials/accounts_test.exs
@@ -10,15 +10,6 @@ defmodule AcolyteTrials.AccountsTest do
     @update_attrs %{github_username: "some updated github_username", name: "some updated name"}
     @invalid_attrs %{github_username: nil, name: nil}
 
-    def user_fixture(attrs \\ %{}) do
-      {:ok, user} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> Accounts.create_user()
-
-      user
-    end
-
     test "list_users/0 returns all users" do
       user = user_fixture()
       assert Accounts.list_users() == [user]

--- a/test/acolyte_trials/devices_test.exs
+++ b/test/acolyte_trials/devices_test.exs
@@ -12,12 +12,24 @@ defmodule AcolyteTrials.DevicesTest do
 
     test "list_devices/0 returns all devices" do
       device = device_fixture()
-      assert Devices.list_devices() == [device]
+      retrieved_devices = Devices.list_devices()
+
+      assert retrieved_devices != []
+
+      retrieved_device = hd(retrieved_devices)
+      assert retrieved_device.id == device.id
     end
 
     test "get_device!/1 returns the device with given id" do
       device = device_fixture()
-      assert Devices.get_device!(device.id) == device
+      retrieved_device = Devices.get_device!(device.id)
+      assert retrieved_device.id == device.id
+    end
+
+    test "get_device_by/1 returns the device with given param" do
+      device = device_fixture(@valid_attrs)
+      retrieved_device = Devices.get_device_by(@valid_attrs)
+      assert retrieved_device.id == device.id
     end
 
     test "create_device/1 with valid data creates a device" do
@@ -38,7 +50,9 @@ defmodule AcolyteTrials.DevicesTest do
     test "update_device/2 with invalid data returns error changeset" do
       device = device_fixture()
       assert {:error, %Ecto.Changeset{}} = Devices.update_device(device, @invalid_attrs)
-      assert device == Devices.get_device!(device.id)
+
+      retrieved_device = Devices.get_device!(device.id)
+      assert retrieved_device.id == device.id
     end
 
     test "delete_device/1 deletes the device" do

--- a/test/acolyte_trials/devices_test.exs
+++ b/test/acolyte_trials/devices_test.exs
@@ -10,15 +10,6 @@ defmodule AcolyteTrials.DevicesTest do
     @update_attrs %{config_hash: "some updated config_hash"}
     @invalid_attrs %{config_hash: nil}
 
-    def device_fixture(attrs \\ %{}) do
-      {:ok, device} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> Devices.create_device()
-
-      device
-    end
-
     test "list_devices/0 returns all devices" do
       device = device_fixture()
       assert Devices.list_devices() == [device]

--- a/test/acolyte_trials_web/channels/device_channel_test.exs
+++ b/test/acolyte_trials_web/channels/device_channel_test.exs
@@ -1,0 +1,16 @@
+defmodule AcolyteTrialsWeb.DeviceChannelTest do
+  use AcolyteTrialsWeb.ChannelCase
+
+  alias AcolyteTrialsWeb.UserSocket
+
+  setup do
+    device = device_fixture()
+    {:ok, socket} = connect(UserSocket, %{"token" => device.config_hash})
+
+    {:ok, socket: socket, device: device}
+  end
+
+  test "join devices channel", %{socket: socket, device: device} do
+    assert {:ok, _reply, socket} = subscribe_and_join(socket, "devices:#{device.id}")
+  end
+end

--- a/test/acolyte_trials_web/channels/user_socket_test.exs
+++ b/test/acolyte_trials_web/channels/user_socket_test.exs
@@ -1,0 +1,20 @@
+defmodule AcolyteTrials.Channels.UserSocketTest do
+  use AcolyteTrialsWeb.ChannelCase, async: true
+
+  alias AcolyteTrialsWeb.UserSocket
+
+  setup do
+    device = device_fixture()
+    {:ok, device: device}
+  end
+
+  test "socket authentication with valid token", %{device: device} do
+    assert {:ok, socket} = connect(UserSocket, %{"token" => device.config_hash})
+    assert socket.assigns.device_id == device.config_hash
+  end
+
+  test "socket authentication with invalid token" do
+    assert :error = connect(UserSocket, %{"token" => "123"})
+    assert :error = connect(UserSocket, %{})
+  end
+end

--- a/test/acolyte_trials_web/controllers/device_controller_test.exs
+++ b/test/acolyte_trials_web/controllers/device_controller_test.exs
@@ -1,16 +1,9 @@
 defmodule AcolyteTrialsWeb.DeviceControllerTest do
   use AcolyteTrialsWeb.ConnCase
 
-  alias AcolyteTrials.Devices
-
   @create_attrs %{config_hash: "some config_hash"}
   @update_attrs %{config_hash: "some updated config_hash"}
   @invalid_attrs %{config_hash: nil}
-
-  def fixture(:device) do
-    {:ok, device} = Devices.create_device(@create_attrs)
-    device
-  end
 
   describe "index" do
     test "lists all devices", %{conn: conn} do
@@ -83,7 +76,7 @@ defmodule AcolyteTrialsWeb.DeviceControllerTest do
   end
 
   defp create_device(_) do
-    device = fixture(:device)
+    device = device_fixture(@create_attrs)
     {:ok, device: device}
   end
 end

--- a/test/acolyte_trials_web/controllers/user_controller_test.exs
+++ b/test/acolyte_trials_web/controllers/user_controller_test.exs
@@ -1,16 +1,9 @@
 defmodule AcolyteTrialsWeb.UserControllerTest do
   use AcolyteTrialsWeb.ConnCase
 
-  alias AcolyteTrials.Accounts
-
   @create_attrs %{github_username: "some github_username", name: "some name"}
   @update_attrs %{github_username: "some updated github_username", name: "some updated name"}
   @invalid_attrs %{github_username: nil, name: nil}
-
-  def fixture(:user) do
-    {:ok, user} = Accounts.create_user(@create_attrs)
-    user
-  end
 
   describe "index" do
     test "lists all users", %{conn: conn} do
@@ -75,6 +68,7 @@ defmodule AcolyteTrialsWeb.UserControllerTest do
     test "deletes chosen user", %{conn: conn, user: user} do
       conn = delete(conn, Routes.user_path(conn, :delete, user))
       assert redirected_to(conn) == Routes.user_path(conn, :index)
+
       assert_error_sent 404, fn ->
         get(conn, Routes.user_path(conn, :show, user))
       end
@@ -82,7 +76,7 @@ defmodule AcolyteTrialsWeb.UserControllerTest do
   end
 
   defp create_user(_) do
-    user = fixture(:user)
+    user = user_fixture(@create_attrs)
     {:ok, user: user}
   end
 end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -19,7 +19,7 @@ defmodule AcolyteTrialsWeb.ChannelCase do
     quote do
       # Import conveniences for testing with channels
       use Phoenix.ChannelTest
-      import AcolyteTrials.TestHelpers
+      import AcolyteTrials.Fixtures
 
       # The default endpoint for testing
       @endpoint AcolyteTrialsWeb.Endpoint

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -19,6 +19,7 @@ defmodule AcolyteTrialsWeb.ChannelCase do
     quote do
       # Import conveniences for testing with channels
       use Phoenix.ChannelTest
+      import AcolyteTrials.TestHelpers
 
       # The default endpoint for testing
       @endpoint AcolyteTrialsWeb.Endpoint

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -22,6 +22,7 @@ defmodule AcolyteTrialsWeb.ConnCase do
       # Import conveniences for testing with connections
       use Phoenix.ConnTest
       alias AcolyteTrialsWeb.Router.Helpers, as: Routes
+      import AcolyteTrials.Fixtures
 
       # The default endpoint for testing
       @endpoint AcolyteTrialsWeb.Endpoint

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -24,6 +24,7 @@ defmodule AcolyteTrials.DataCase do
       import Ecto.Changeset
       import Ecto.Query
       import AcolyteTrials.DataCase
+      import AcolyteTrials.TestHelpers
     end
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -24,7 +24,7 @@ defmodule AcolyteTrials.DataCase do
       import Ecto.Changeset
       import Ecto.Query
       import AcolyteTrials.DataCase
-      import AcolyteTrials.TestHelpers
+      import AcolyteTrials.Fixtures
     end
   end
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,4 +1,4 @@
-defmodule AcolyteTrials.TestHelpers do
+defmodule AcolyteTrials.Fixtures do
   alias AcolyteTrials.{Accounts, Devices}
 
   def user_fixture(attrs \\ %{}) do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -13,10 +13,10 @@ defmodule AcolyteTrials.TestHelpers do
     user
   end
 
-  def insert_device(attrs \\ %{}) do
+  def device_fixture(attrs \\ %{}) do
     {:ok, device} =
       attrs
-      |> Enum.into( %{
+      |> Enum.into(%{
         config_hash: "12345678910"
       })
       |> Devices.create_device()

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,0 +1,26 @@
+defmodule AcolyteTrials.TestHelpers do
+  alias AcolyteTrials.{Accounts, Devices}
+
+  def user_fixture(attrs \\ %{}) do
+    {:ok, user} =
+      attrs
+      |> Enum.into(%{
+        name: "Some User",
+        github_username: "user#{System.unique_integer([:positive])}"
+      })
+      |> Accounts.create_user()
+
+    user
+  end
+
+  def insert_device(attrs \\ %{}) do
+    {:ok, device} =
+      attrs
+      |> Enum.into( %{
+        config_hash: "12345678910"
+      })
+      |> Devices.create_device()
+
+    device
+  end
+end


### PR DESCRIPTION
1. When a device connects to the WebSocket, it is authenticated if the provided token is found in the list of registered devices.
    * The `token` is set as the device's `config_hash`.
    * If the device is able to successfully connect to the socket, they can join the `devices:{token}` channel

2. Added `Devices.get_device_by/1` and associated test
3. Updated `user` and `device` tests to use new fixtures from `support/fixtures.ex`
4. Updated `Devices` context to preload the `user` association by default when retrieving devices.

closes #2 